### PR TITLE
fix that problematic / in the commented out get-all-comments API rout…

### DIFF
--- a/app/api/comment_routes.py
+++ b/app/api/comment_routes.py
@@ -25,7 +25,7 @@ def new_comment():
     return {'errors': validation_errors_to_error_messages(form.errors)}, 400
 
 
-# @comment_routes.route('/')
+# @comment_routes.route('')
 # # @login_required
 # def posts():
 #     posts = Post.query.all()


### PR DESCRIPTION
…e, just in case I ever need to use it